### PR TITLE
made home page more accessible for key-board users

### DIFF
--- a/css/basic.css
+++ b/css/basic.css
@@ -22,6 +22,13 @@ https://colorhunt.co/palette/ff8787f8c4b4e5ebb2bce29e */
   --gradient: linear-gradient(90deg, var(--green), var(--pink));
 }
 
+/* focus visible styling to interactive element to make the site accessible to  keyboard users */
+.btn:focus-visible {
+  outline: 0.3rem dotted red;
+  transform: scale(1.1);
+}
+
+
 /* TO REMOVE THE UP AND DOWN ARROWS ON Input tags of type="number" */
 input::-webkit-outer-spin-button,
 input::-webkit-inner-spin-button {

--- a/index.html
+++ b/index.html
@@ -19,23 +19,20 @@
             <div class="about_div_text">
                 <h1>Have Fun With Maths ✨</h1>
                 <span class="about_arito">Arito is a WebApp built for practicing arithematic skills. It is designed with creativity and to have a joyful experience. It is built primarily for kids who need to practice their mathematical skills, but this can be used by anybody.</span>
-                <a href="pages/main.html" class="links bg_green">LET'S START! 🔥</a>
+                <a href="pages/main.html" class="links bg_green btn">LET'S START! 🔥</a>
             </div>
         </div>
 
-<div class="other_links_div">
-    <a href="https://www.buymeacoffee.com/prakhartiwari0" class="links bg_light_green" target="_blank" >Support the Creator 🤗</a>
-    <a href="https://github.com/prakhartiwari0/Arito" class="links bg_light_pink" target="_blank" >Contribute to this Project 😇</a>
-    <a href="https://github.com/prakhartiwari0/Arito/issues/new/choose" target="_blank" class="links bg_pink">Bug Report or Feature Request 📝</a>
-</div>
+    <div class="other_links_div">
+        <a href="https://www.buymeacoffee.com/prakhartiwari0" class="links bg_light_green btn" target="_blank" >Support the Creator 🤗</a>
+        <a href="https://github.com/prakhartiwari0/Arito" class="links bg_light_pink btn" target="_blank" >Contribute to this Project 😇</a>
+        <a href="https://github.com/prakhartiwari0/Arito/issues/new/choose" target="_blank" class="links bg_pink btn">Bug Report or Feature Request 📝</a>
+    </div>
     </div>
     <footer>
-        <a href="https://www.producthunt.com/posts/arito?utm_source=badge-featured&utm_medium=badge&utm_souce=badge-arito" target="_blank"><img src="https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=367945&theme=light" alt="Arito - Your&#0032;place&#0032;to&#0032;play&#0032;with&#0032;DAMS | Product Hunt" style="width: 250px; height: 54px;" width="250" height="54" /></a>
-        <a href="https://www.heyprakhar.xyz/links" target="_blank" class="contact_link">Developed by <strong>Prakhar</strong></a>
+        <a href="https://www.producthunt.com/posts/arito?utm_source=badge-featured&utm_medium=badge&utm_souce=badge-arito" target="_blank" class="btn"><img src="https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=367945&theme=light" alt="Arito - Your&#0032;place&#0032;to&#0032;play&#0032;with&#0032;DAMS | Product Hunt" style="width: 250px; height: 54px;" width="250" height="54" /></a>
+        <a href="https://www.heyprakhar.xyz/links" target="_blank" class="contact_link btn">Developed by <strong>Prakhar</strong></a>
     </footer>
-
-
-
 
 </body>
 <script src="js/index.js"></script>


### PR DESCRIPTION
Hello, thanks for giving us the opportunity to contribute to your open source project.
In this first contrubution of mine, my intention is to make this home page accessible to keyboard users by adding a focus-visible states, because those using the tab key to navigate sites will know which link they are on. [here is a preview](https://arito-accessibility-preview.netlify.app/), ensure to navigate throught the tab key to see the state.

From [mdn web doc](https://developer.mozilla.org/en-US/docs/Web/CSS/:focus-visible) **"Make sure the visual focus indicator can be seen by people with low vision. This will also benefit anyone use a screen in a brightly lit space (like outside in the sun). [WCAG 2.1 SC 1.4.11 Non-Text Contrast](https://www.w3.org/WAI/WCAG21/Understanding/non-text-contrast.html) requires that the visual focus indicator be at least 3 to 1."**

Hopefully very soon I'll add more effort to make it more accessible. Feel Free to correct me, I also a beginer when it comes to web content accessiblity.