### PR TITLE
Provide the user with an option to resume the test or not.

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -261,6 +261,14 @@ body {
 	justify-content: center;
 	width: 100%;
 }
+
+.test_page .question_div .pause_btn_div {
+	margin-top: 0.5em;
+	display: flex;
+	justify-content: center;
+	width: 100%;
+}
+
 .test_page .question_div .submit_btn_div button {
 	cursor: pointer;
 	font-size: 0.3em;
@@ -270,7 +278,21 @@ body {
 	border-radius: 12% 88% 11% 89% / 91% 13% 87% 9%;
 }
 
+.test_page .question_div .pause_btn_div button {
+	cursor: pointer;
+	font-size: 0.3em;
+	font-family: 'Indie Flower', cursive;
+	padding: 0.5em 0.5em;
+	border: 2px solid black;
+	border-radius: 12% 88% 11% 89% / 91% 13% 87% 9%;
+}
+
 .test_page .question_div .submit_btn_div button:is(:active, :focus) {
+	background-color: var(--green);
+	transform: scale(0.8);
+}
+
+.test_page .question_div .pause_btn_div button:is(:active, :focus) {
 	background-color: var(--green);
 	transform: scale(0.8);
 }
@@ -367,6 +389,10 @@ body {
 
 	.test_page .question_div .submit_btn_div button:is(:hover) {
 		background-color: var(--green);
+	}
+
+	.test_page .question_div .pause_btn_div button:is(:hover) {
+		background-color: var(--pink);
 	}
 }
 

--- a/css/main.css
+++ b/css/main.css
@@ -327,7 +327,7 @@ body {
   	background-color: rgba(0, 0, 0, 0.5);
 }
 
-.modal .modal-content {
+.modal .modal_content {
   background-color: #fefefe;
   margin: 15% auto;
   padding: 20px;
@@ -341,20 +341,20 @@ body {
   box-shadow: 0 5px 8px 0 rgba(0, 0, 0, 0.2), 0 7px 20px 0 rgba(0, 0, 0, 0.17);
 }
 
-.modal .modal-content p {
+.modal .modal_content p {
 	font-family: 'Indie Flower', cursive;
 	/* margin-top: 2em; */
 	font-size: 1em;
 }
 
-.modal .modal-content .resume_btn_div {
+.modal .modal_content .resume_btn_div {
 	margin-top: 0.5em;
 	display: flex;
 	justify-content: center;
 	width: 100%;
 }
 
-.modal .modal-content .resume_btn_div button {
+.modal .modal_content .resume_btn_div button {
 	cursor: pointer;
 	font-size: 1em;
 	font-family: 'Indie Flower', cursive;
@@ -423,7 +423,7 @@ body {
 		background-color: var(--pink);
 	}
 
-	.modal .modal-content .resume_btn_div button:is(:hover) {
+	.modal .modal_content .resume_btn_div button:is(:hover) {
 		background-color: var(--green);
 	}
 }

--- a/css/main.css
+++ b/css/main.css
@@ -290,6 +290,34 @@ body {
 	}
 }
 
+/* Pause/Resume modal */
+
+.modal {
+	display: none;
+	position: fixed;
+	z-index: 1;
+	left: 0;
+  	top: 0;
+  	width: 100%;
+  	height: 100%;
+  	overflow: auto;
+  	background-color: rgba(0, 0, 0, 0.5);
+}
+
+.modal-content {
+  background-color: #fefefe;
+  margin: 15% auto;
+  padding: 20px;
+  width: 80%;
+  box-shadow: 0 5px 8px 0 rgba(0, 0, 0, 0.2), 0 7px 20px 0 rgba(0, 0, 0, 0.17);
+}
+
+.background-blur {
+  /* overflow: hidden; */
+  filter: blur(10px);
+  -webkit-filter: blur(10px);
+}
+
 /* --------------- START TEST --------------- */
 
 .start_test_div {

--- a/css/main.css
+++ b/css/main.css
@@ -320,18 +320,46 @@ body {
 	z-index: 1;
 	left: 0;
   	top: 0;
+	font-size: 1.5rem;
   	width: 100%;
   	height: 100%;
   	overflow: auto;
   	background-color: rgba(0, 0, 0, 0.5);
 }
 
-.modal-content {
+.modal .modal-content {
   background-color: #fefefe;
   margin: 15% auto;
   padding: 20px;
-  width: 80%;
+  width: 50%;
+  height: fit-content;
+  background-color: #ff8787a0;
+  border-radius: 97% 3% 96% 4% / 4% 99% 1% 96%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
   box-shadow: 0 5px 8px 0 rgba(0, 0, 0, 0.2), 0 7px 20px 0 rgba(0, 0, 0, 0.17);
+}
+
+.modal .modal-content p {
+	font-family: 'Indie Flower', cursive;
+	/* margin-top: 2em; */
+	font-size: 1em;
+}
+
+.modal .modal-content .resume_btn_div {
+	margin-top: 0.5em;
+	display: flex;
+	justify-content: center;
+	width: 100%;
+}
+
+.modal .modal-content .resume_btn_div button {
+	cursor: pointer;
+	font-size: 1em;
+	font-family: 'Indie Flower', cursive;
+	padding: 0.5em 0.5em;
+	border: 2px solid black;
 }
 
 .background-blur {
@@ -393,6 +421,10 @@ body {
 
 	.test_page .question_div .pause_btn_div button:is(:hover) {
 		background-color: var(--pink);
+	}
+
+	.modal .modal-content .resume_btn_div button:is(:hover) {
+		background-color: var(--green);
 	}
 }
 

--- a/js/main.js
+++ b/js/main.js
@@ -34,7 +34,7 @@ const downNumber = document.querySelector('.downNumber')
 const retestButton = document.querySelector('.retest_button')
 const newTestButton = document.querySelector('.new_test_button')
 const pauseButton = document.querySelector('.pause_button')
-const resumeButton = document.querySelector('.resume_test')
+const resumeButton = document.querySelector('.resume_button')
 
 // RESULTS PAGE NODES REFERENCES
 const result_page = document.querySelector('.result_page')
@@ -229,8 +229,12 @@ function examiner(up_number, down_number, sign_of_question, answer_of_student) {
 }
 
 function resultGenerator() {
+	/* If the user has ever paused during the test then a final calculation
+	   for totalPausedTime is done before we give that value to total_time. 
+	   If the user has never paused then we do the else condition where we find 
+	   the total time using end_time - start_time */
 	if (paused === true) {
-		let current_time = Date.now();
+		let current_time = Date.now()
 		console.log(current_time)
 
 		final_paused_time = current_time - start_time
@@ -239,7 +243,7 @@ function resultGenerator() {
 		totalPausedTime += final_paused_time
 		console.log(totalPausedTime)
 
-		total_time = totalPausedTime;
+		total_time = totalPausedTime
 		console.log("paused")
 	} else {
 		total_time = end_time - start_time
@@ -556,18 +560,22 @@ function nextQuestion() {
 	questionBoxGenerator()
 }
 
+/* When the user has paused at least once we change the paused boolean value to 
+   true, and we take the currentTime when the user paused the test and subtract it 
+   with the start time to get the amount of time the user has written the test until 
+   now and add it to the totalPauseTime. When the user clicks resume button we set
+   start_time to a new Date.now and thus we get the time when the user started from
+   the resume and when he clicks pause again we pause and do the subtraction again
+   and add it to the totalPauseTime again. This goes on a loop until the user decides
+   to finish the test and during that time a final addition is done to the totalPausedTime
+   and is take as the totalTime. */
+
 function pauseTest() {
- 	paused = true;
-	console.log(start_time)
+ 	paused = true
 	
-	let currentTime = Date.now();
-	// console.log(currentTime)
-	
-	let current_paused_time = currentTime - start_time;
-	console.log(current_paused_time)
-	
+	let currentTime = Date.now()
+	let current_paused_time = currentTime - start_time
 	totalPausedTime += current_paused_time
-	console.log(totalPausedTime)
 	
 	document.getElementById("pause_modal").style.display = "block"
 	document.body.classList.add("modal-open")
@@ -575,16 +583,15 @@ function pauseTest() {
 }
 
 function resumeTest() {
-
-	start_time = Date.now();
-	console.log(start_time);
-	document.getElementById("pause_modal").style.display = "none";
-	document.body.classList.remove("modal-open");
+	start_time = Date.now()
+	console.log(start_time)
+	document.getElementById("pause_modal").style.display = "none"
+	document.body.classList.remove("modal-open")
 	document.getElementById("question-container").classList.remove('background-blur')
 }
 
 function retakeTest() {
-	paused = false
+	paused = false // when the user retakes the test we set paused back to false
 	totalPausedTime = 0
 	result_page.style.display = 'none'
 	questions_array = []

--- a/js/main.js
+++ b/js/main.js
@@ -28,7 +28,6 @@ const q_number = document.querySelector('.q_number')
 const total_qs = document.querySelector('.total_qs')
 const prev_btn = document.querySelector('.prev_question_btn')
 const next_btn = document.querySelector('.next_question_btn')
-const pause_Button = document.querySelector('.pause_button')
 const upNumber = document.querySelector('.upNumber')
 const sign = document.querySelector('.sign')
 const downNumber = document.querySelector('.downNumber')
@@ -75,8 +74,8 @@ let real_answers_array = []
 let right_or_wrong_array = []
 let marks = 0
 let current_q_no = 1
-let paused = false;
-let totalPausedTime = 0;
+let paused = false
+let totalPausedTime = 0
 
 function get_min_max_numbers(diff_lvl) {
     let maximum_num;
@@ -230,12 +229,25 @@ function examiner(up_number, down_number, sign_of_question, answer_of_student) {
 }
 
 function resultGenerator() {
-	// if (paused == true) {
-	// 	total_time = totalPausedTime;
-	// } else {
-	// 	total_time = end_time - start_time
-	// }	
-	total_time = end_time - start_time
+	if (paused === true) {
+		let current_time = Date.now();
+		console.log(current_time)
+
+		final_paused_time = current_time - start_time
+		console.log(final_paused_time)
+
+		totalPausedTime += final_paused_time
+		console.log(totalPausedTime)
+
+		total_time = totalPausedTime;
+		console.log("paused")
+	} else {
+		total_time = end_time - start_time
+		console.log("non paused")
+	}	
+	console.log(start_time)
+	console.log(end_time)
+	console.log(total_time)
 	time_taken_seconds = parseInt(total_time / 1000)
 	time_taken_minutes = 00
 	time_taken_hours = 00
@@ -437,6 +449,7 @@ function volume_updater() {
 
 function createTestpage(){
     start_time = Date.now()
+	console.log(start_time)
     sound_player("click_sound", "start")
     sound_player("background_music", "stop")
     sound_player("test_page_bg_music", "start", "loop")
@@ -545,9 +558,16 @@ function nextQuestion() {
 
 function pauseTest() {
  	paused = true;
+	console.log(start_time)
+	
 	let currentTime = Date.now();
+	// console.log(currentTime)
+	
 	let current_paused_time = currentTime - start_time;
+	console.log(current_paused_time)
+	
 	totalPausedTime += current_paused_time
+	console.log(totalPausedTime)
 	
 	document.getElementById("pause_modal").style.display = "block"
 	document.body.classList.add("modal-open")
@@ -557,13 +577,15 @@ function pauseTest() {
 function resumeTest() {
 
 	start_time = Date.now();
-	
+	console.log(start_time);
 	document.getElementById("pause_modal").style.display = "none";
 	document.body.classList.remove("modal-open");
 	document.getElementById("question-container").classList.remove('background-blur')
 }
 
 function retakeTest() {
+	paused = false
+	totalPausedTime = 0
 	result_page.style.display = 'none'
 	questions_array = []
 	user_answers_array = []

--- a/js/main.js
+++ b/js/main.js
@@ -28,11 +28,14 @@ const q_number = document.querySelector('.q_number')
 const total_qs = document.querySelector('.total_qs')
 const prev_btn = document.querySelector('.prev_question_btn')
 const next_btn = document.querySelector('.next_question_btn')
+const pause_Button = document.querySelector('.pause_button')
 const upNumber = document.querySelector('.upNumber')
 const sign = document.querySelector('.sign')
 const downNumber = document.querySelector('.downNumber')
 const retestButton = document.querySelector('.retest_button')
 const newTestButton = document.querySelector('.new_test_button')
+const pauseButton = document.querySelector('.pause_button')
+const resumeButton = document.querySelector('.resume_test')
 
 // RESULTS PAGE NODES REFERENCES
 const result_page = document.querySelector('.result_page')
@@ -57,6 +60,7 @@ question_done_btn.addEventListener('click', getAnswer)
 prev_btn.addEventListener('click', prevQuestion)
 next_btn.addEventListener('click', nextQuestion)
 
+// pause_Button.addEventListener('click', pauseTest)
 // ENGINE OF THE TEST
 // 1. Decide up and down numbers
 // 2. Decide the sign
@@ -71,6 +75,8 @@ let real_answers_array = []
 let right_or_wrong_array = []
 let marks = 0
 let current_q_no = 1
+let paused = false;
+let totalPausedTime = 0;
 
 function get_min_max_numbers(diff_lvl) {
     let maximum_num;
@@ -224,6 +230,11 @@ function examiner(up_number, down_number, sign_of_question, answer_of_student) {
 }
 
 function resultGenerator() {
+	// if (paused == true) {
+	// 	total_time = totalPausedTime;
+	// } else {
+	// 	total_time = end_time - start_time
+	// }	
 	total_time = end_time - start_time
 	time_taken_seconds = parseInt(total_time / 1000)
 	time_taken_minutes = 00
@@ -532,6 +543,26 @@ function nextQuestion() {
 	questionBoxGenerator()
 }
 
+function pauseTest() {
+ 	paused = true;
+	let currentTime = Date.now();
+	let current_paused_time = currentTime - start_time;
+	totalPausedTime += current_paused_time
+	
+	document.getElementById("pause_modal").style.display = "block"
+	document.body.classList.add("modal-open")
+	document.getElementById("question-container").classList.add('background-blur')	
+}
+
+function resumeTest() {
+
+	start_time = Date.now();
+	
+	document.getElementById("pause_modal").style.display = "none";
+	document.body.classList.remove("modal-open");
+	document.getElementById("question-container").classList.remove('background-blur')
+}
+
 function retakeTest() {
 	result_page.style.display = 'none'
 	questions_array = []
@@ -558,3 +589,5 @@ function newTest() {
 
 retestButton.addEventListener('click', retakeTest)
 newTestButton.addEventListener('click', newTest)
+pauseButton.addEventListener('click', pauseTest)
+resumeButton.addEventListener('click', resumeTest)

--- a/pages/main.html
+++ b/pages/main.html
@@ -87,7 +87,7 @@
         <h2 class="question_details">Question: <span class="q_number"></span>/<span class="total_qs"></span> </h2>
     </header>
 
-    <div class="question_container">
+    <div id ="question-container" class="question_container">
       <button class="prev_question_btn">&#8249;</button>
       <div class="question_div">
         <div class="question_numbers_div">
@@ -116,12 +116,20 @@
         <div class="submit_btn_div">
             <button type="submit" class="question_done_btn">Done!</button>
         </div>
+        <div>
+          <button class="pause_button">⏸️ Pause</button>
+        </div>
       </div>
       <button class="next_question_btn">&#8250;</button>
     </div>
     </div>
 
-
+    <div id="pause_modal" class="modal">
+      <div class="modal-content">
+        <p>Paused</p>
+        <button class="resume_test">⏯️ Resume</button>
+      </div>
+    </div>
 
 
     <div class="test_form">

--- a/pages/main.html
+++ b/pages/main.html
@@ -116,8 +116,8 @@
         <div class="submit_btn_div">
             <button type="submit" class="question_done_btn">Done!</button>
         </div>
-        <div>
-          <button class="pause_button">⏸️ Pause</button>
+        <div class="pause_btn_div">
+          <button class="pause_button">Pause!</button>
         </div>
       </div>
       <button class="next_question_btn">&#8250;</button>

--- a/pages/main.html
+++ b/pages/main.html
@@ -125,11 +125,11 @@
     </div>
 
     <div id="pause_modal" class="modal">
-      <div class="modal-content">
+      <div class="modal_content">
         <p>Paused!</p>
         <p>Feel free to click below to continue the test</p>
         <div class="resume_btn_div">
-          <button class="resume_test">Resume</button>
+          <button class="resume_button">Resume</button>
         </div>
       </div>
     </div>

--- a/pages/main.html
+++ b/pages/main.html
@@ -126,8 +126,11 @@
 
     <div id="pause_modal" class="modal">
       <div class="modal-content">
-        <p>Paused</p>
-        <button class="resume_test">⏯️ Resume</button>
+        <p>Paused!</p>
+        <p>Feel free to click below to continue the test</p>
+        <div class="resume_btn_div">
+          <button class="resume_test">Resume</button>
+        </div>
       </div>
     </div>
 


### PR DESCRIPTION

<!-- If your PR fixes a complete issue you please replace "Related to" with "Fixes" in the heading below -->
### Related to #70 

## Describe the changes you've made
- Created a button that lets users to pause the test
- On click a modal opens that blurs the test in the background
- Also the modal has a resume button to continue with the test
- Made changes to the javascript file to measure the time accurately with the pause function implement

<!-- To select a checkbox, add an x in between the brackets [x] -->

### Type of change
What sort of change have you made:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How Has This Been Tested?
I did a local machine test and I have tested whether the correct time is getting displayed or not with some console logs too.


## Checklist:
- [ ] My code follows the guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly wherever it was hard to understand.
- [ ] I have made corresponding changes to the documentation.

<!-- Please upload clear Images/Videos which shows every aspect of the change (For E.g. How does the app behaves when screen size is changed) -->
<!-- You can choose to upload between Screenshots and Recording, but you MUST UPLOAD AT LEAST ONE OF THEM -->

## Screenshots (Images)
| Before the changes | After the Changes |
| --- | --- |
| <img width="1986" alt="Screenshot 2023-01-30 at 4 56 42 PM" src="https://user-images.githubusercontent.com/80635529/215496864-ea0d15c2-6c93-4116-a760-12543bc9a49c.png"> |<img width="1986" alt="Screenshot 2023-01-30 at 4 53 47 PM" src="https://user-images.githubusercontent.com/80635529/215496219-4d11e21f-294b-45a9-b0b2-c4751167fa84.png"> |

- On pausing 

<img width="1986" alt="Screenshot 2023-01-30 at 4 59 49 PM" src="https://user-images.githubusercontent.com/80635529/215497565-6df18ffa-7c0c-410a-9555-a223a19d16e2.png">



<!--  Make new table rows to add more than 2 screenshots-->





